### PR TITLE
Clang Format Capability + README

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,107 @@
+---
+AccessModifierOffset: -4
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Right
+# AlignOperands: Align    # v12
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowAllArgumentsOnNextLine: true
+
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: true
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: NonAssignment
+
+# BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: false
+
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+IndentPPDirectives: AfterHash
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: true
+
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeParens: NonEmptyParentheses
+SpaceInEmptyParentheses: false
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: "c++17"
+
+TabWidth: 4
+UseTab: Never
+ForEachMacros: [ BOOST_FOREACH ]
+
+---
+Language: ObjC
+BasedOnStyle: Chromium
+AlignTrailingComments: true
+BreakBeforeBraces: Allman
+ColumnLimit: 0
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1
+TabWidth: 4
+UseTab: Never
+...

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+[![Build](https://github.com/snidercs/bot-2024/actions/workflows/build.yml/badge.svg)](https://github.com/snidercs/bot-2024/actions/workflows/build.yml)
+# Robot Firmware FRC 2025
+## Features
+- 
+
+## Clone
+Should be possible inside vscode, or...
+
+```bash
+git clone --recursive git@github.com:snidercs/frc-bot-2025.git
+```
+
+## Clang Format
+The c++ code should be formatted before submitting pull requests. Do this with python or gradle.
+
+```bash
+# Run the python script directly
+python3 util/format.py
+# or do it wrapped in a gradle task
+./gradlew clangFormat
+```
+
+## Requirements
+
+### Dependencies
+The `gradle build` and `gradle deploy` tasks both need roboRIO libraries and headers in place.  Most of them are handled by wpilib, but some need special attention.
+
+**Linux**
+```bash
+# multilib support is needed for cross building, install if needed
+sudo apt-get install gcc-multilib g++-multilib cmake python3 python3-pip
+```
+
+**macOS**
+
+### Firmware Build with WPIlib VSCode
+After LuaJIT is compiled, open a terminal and do:
+```bash
+./gradlew build
+```
+
+## Testing
+Run all unit tests.
+```bash
+./gradlew check
+```
+
+## Deployment
+Run the following command to deploy code to the roboRIO
+```bash
+./gradlew deploy
+```
+
+If it gives problems, cleaning the project could help. The `--info` option could give more information too.
+```bash
+./gradlew clean
+./gradlew deploy --info
+```

--- a/build.gradle
+++ b/build.gradle
@@ -99,3 +99,14 @@ model {
         }
     }
 }
+
+ task clangFormat {
+     doLast {
+         exec {
+             workingDir "${projectDir}"
+             executable 'python3'
+             args "${projectDir}/util/format.py"
+         }
+     }
+ }
+ 

--- a/util/format.py
+++ b/util/format.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+## Make sure all code files are saved before running this script.  It does zero
+# checking of saved status.
+
+# Returns a list of filenames that need formatted.
+def code_files():
+    import glob
+    src = glob.glob("src/**/*.cpp", recursive=True)
+    src += glob.glob("src/**/*.hpp", recursive=True)
+    src += glob.glob("src/**/*.h", recursive=True)
+    return src
+
+# This can actually be called anything, not just main.  But function names
+# should to some extent indicate what they actually do.
+def main():
+    import subprocess
+    print ("Formatting Code:")
+    for f in code_files():
+        if 'src/sol' in f:
+            continue
+        print ("  %s" % f)
+        subprocess.call (['clang-format', '-i', f])
+    print ("done!")
+
+# This part, the  "__name__ == '__main__'" is telling Python this is where
+# code execution should start.  This is the proper way to to begin
+# a program written in Python.
+if __name__ == '__main__':
+    main()  # call the real program function.


### PR DESCRIPTION
Adds a README with basic build and deployment information.  Also adds a python script integrated with `gradlew` that will format all of the c++ code in bulk.  To use it:

```
./gradlew clangFormat
```

This merely runs the script `util/format.py`