### PR TITLE
refactor: lifter to dualmotor class for intake and elevator

### DIFF
--- a/pybot/dualmotor.py
+++ b/pybot/dualmotor.py
@@ -2,22 +2,19 @@ from phoenix6.hardware import talon_fx
 from phoenix6.controls.follower import Follower
 from phoenix6.signals import NeutralModeValue
 
-class Lifter:
+class DualMotor:
     def __init__(self, master_id, follower_id) -> None:
         self.motor = talon_fx.TalonFX(master_id)
-        self.motor.setNeutralMode(NeutralModeValue.BRAKE)
         self.follower = talon_fx.TalonFX(follower_id)
-        self.follower.set_control(Follower(master_id, True))
+        
+        # Set neutral mode
+        self.motor.setNeutralMode(NeutralModeValue.BRAKE)
         self.follower.setNeutralMode(NeutralModeValue.BRAKE)
+        self.follower.set_control(Follower(master_id, True))
 
-    def moveDown(self) -> None:
-                self.motor.set(-0.2)
-
-    def moveUp(self) -> None:
-                self.motor.set(0.3)
 
     def stop(self) -> None:
-            self.motor.stopMotor()
+        self.motor.stopMotor()
         
     def setMotor(self, value) -> None:
-            self.motor.set(value)
+        self.motor.set(value)

--- a/pybot/elevator.py
+++ b/pybot/elevator.py
@@ -1,0 +1,42 @@
+from dualmotor import DualMotor
+from phoenix6.controls import DutyCycleOut# , NeutralOut
+from phoenix6.configs import TalonFXConfiguration
+
+HOLDING_POWER = 0.02
+GOING_UP_POWER = 0.7
+GOING_DOWN_POWER = -0.5
+
+class Elevator(DualMotor):
+    def __init__(self, motor1_id, motor2_id):
+        super().__init__(motor1_id, motor2_id)
+        # Additional initialization for the elevator can go here
+
+        # I want to have it torque out at mins and max's, not sure if I'm doing this right here though lol
+
+        # Configure current limits
+        #motor_config = TalonFXConfiguration()
+        #motor_config.SupplyCurrentLimit = 70  # Default limit of 70 A
+        #motor_config.SupplyCurrentLowerLimit = 40  # Reduce to 40 A if at 70 A for 1 second
+        #motor_config.SupplyCurrentLowerTime = 1  # Time in seconds
+        #motor_config.SupplyCurrentLimitEnable = True  # Enable supply current limiting
+        
+        #motor_config.StatorCurrentLimit = 120  # Limit stator to 120 A
+        #motor_config.StatorCurrentLimitEnable = True  # Enable stator current limiting
+        
+        # Apply configuration to both motors
+        #self.motor.configurator = motor_config
+        #self.follower.configurator = motor_config
+
+    def move_to_position(self, position):
+        # Implement logic to move the elevator to a specific position. Not sure on the units yet
+        pass
+
+    def moveUp(self) -> None:
+        self.setMotor(GOING_UP_POWER)
+
+    def moveDown(self) -> None:
+        self.setMotor(GOING_DOWN_POWER)
+
+    def stop(self) -> None:
+        self.motor.stopMotor()
+        self.motor.set_control(DutyCycleOut(HOLDING_POWER))

--- a/pybot/intake.py
+++ b/pybot/intake.py
@@ -1,0 +1,17 @@
+from dualmotor import DualMotor
+
+SHOOTING_POWER = -.4
+LOADING_POWER = -.15
+
+
+class Intake(DualMotor):
+    def __init__(self, motor1_id, motor2_id):
+        super().__init__(motor1_id, motor2_id)
+
+    def shoot(self):
+        """Shoots the coral."""
+        self.setMotor(SHOOTING_POWER)
+    
+    def load(self):
+        """Loads the coral."""  
+        self.setMotor(LOADING_POWER)

--- a/pybot/robotcontainer.py
+++ b/pybot/robotcontainer.py
@@ -13,19 +13,19 @@ from telemetry import Telemetry
 from wpimath.geometry import Pose2d # , Rotation2d
 from phoenix6 import swerve#, SignalLogger
 from wpimath.units import rotationsToRadians
-from lifter import Lifter  # Import the Lifter class
+from intake import Intake  # Import the Intake class
+from elevator import Elevator  # Import the Elevator class
 import wpilib
 import logging
 import math
-from wpimath.kinematics import ChassisSpeeds
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
-MAX_SPEED_SCALING = 0.35
+MAX_SPEED_SCALING = 0.45
 DEAD_BAND = 0.1
 ELEVATOR_MOTOR_ID_1 = 20
-ELEVATOR_MOTOR_ID_2 = 16
+ELEVATOR_MOTOR_ID_2 = 14
 
 INTAKE_MOTOR_ID_TOP = 18
 INTAKE_MOTOR_ID_BOTTOM = 22
@@ -69,9 +69,9 @@ class RobotContainer:
         self.drivetrain = TunerConstants.create_drivetrain()
 
         # Initialize the elevator with motor IDs
-        self.elevator = Lifter(ELEVATOR_MOTOR_ID_1, ELEVATOR_MOTOR_ID_2)
+        self.elevator = Elevator(ELEVATOR_MOTOR_ID_1, ELEVATOR_MOTOR_ID_2)
         # Initialize the intake with motor IDs
-        self.intake = Lifter(INTAKE_MOTOR_ID_TOP, INTAKE_MOTOR_ID_BOTTOM)
+        self.intake = Intake(INTAKE_MOTOR_ID_TOP, INTAKE_MOTOR_ID_BOTTOM)
         
         # Setup telemetry
         self._registerTelemetry()
@@ -137,12 +137,12 @@ class RobotContainer:
         self._joystick.rightTrigger().onTrue(commands2.cmd.runOnce(self.elevator.stop, self.elevator))
 
         self._joystick.leftBumper().whileTrue(commands2.cmd.startEnd(
-            lambda: self.intake.setMotor(-.3),
+            lambda: self.intake.load(),
             lambda: self.intake.stop()
         ))
         # Configure buttons for intake control
         self._joystick.rightBumper().whileTrue(commands2.cmd.startEnd(
-            lambda: self.intake.setMotor(-1),
+            lambda: self.intake.shoot(),
             lambda: self.intake.stop()
         ))
 


### PR DESCRIPTION
features: 
Elevator no longer falls due to gravity because there's consistent power being pushed to the elevator on enable. 

beginning current limits so that it's torqued out when at max and min. 

gptchat: 
https://chatgpt.com/share/67d60bc4-2d50-8005-a3b8-d6ab8696ecaf

Because of that DutyCycle stopping the elevator from dropping, because the shooter was the same class, it also got applied a duty cycle so we don't want that. Instead, I had to do some refactoring. Tested, and it works. 

closes #117 